### PR TITLE
Add initial file writing functionality and file output testing framework

### DIFF
--- a/lib/cobol_to_elixir/parsed.ex
+++ b/lib/cobol_to_elixir/parsed.ex
@@ -3,6 +3,8 @@ defmodule CobolToElixir.Parsed do
             author: nil,
             date_written: nil,
             divisions: [],
+            file_control: [],
+            file_variables: %{},
             procedure: [],
             paragraphs: %{},
             variables: [],

--- a/livebook_examples.livemd
+++ b/livebook_examples.livemd
@@ -29,7 +29,7 @@ In this Livebook, we can install using `Mix.install`
   Mix.install([
     {:cobol_to_elixir,
      git: "git@github.com:TheFirstAvenger/cobol_to_elixir.git",
-     ref: "ad918c91b5b6cef054ad1489c871c6620896e42e"}
+     ref: "c1772939de25c175b6f4a5eb3fbd28f42a32c014"}
   ])
 ```
 
@@ -58,7 +58,7 @@ STOP RUN.
 Now, lets validate that this is correct COBOL by compiling and then executing it using `CobolToElixir.Util.execute_cobol_code!/2`
 
 ```elixir
-"Hello Mike\n" = cobol_output = CobolToElixir.Util.execute_cobol_code!(cobol)
+%{output: "Hello Mike\n"} = CobolToElixir.Util.execute_cobol_code!(cobol)
 ```
 
 Next, let's use `CobolToElixir.convert()` to convert the COBOL code to Elixir:
@@ -151,7 +151,7 @@ STOP RUN.
 Next, we execute that COBOL code to verify it is valid, and to determine the expected output
 
 ```elixir
-cobol_output = CobolToElixir.Util.execute_cobol_code!(cobol)
+%{output: cobol_output} = CobolToElixir.Util.execute_cobol_code!(cobol)
 IO.puts(cobol_output)
 ```
 

--- a/test/cobol_to_elixir/csis_cobol_examples/iterif_test.exs
+++ b/test/cobol_to_elixir/csis_cobol_examples/iterif_test.exs
@@ -46,6 +46,6 @@ defmodule CobolToElixir.CSISCOBOLExamples.IterifTest do
     expected_output =
       "Enter First Number      : Enter Second Number     : Enter operator (+ or *) : Result is = 11\nEnter First Number      : Enter Second Number     : Enter operator (+ or *) : Result is = 11\nEnter First Number      : Enter Second Number     : Enter operator (+ or *) : Result is = 11\n"
 
-    assert_output_equal(cobol, ElixirFromCobol.Test1, expected_output, input)
+    assert_output_equal(cobol, ElixirFromCobol.Test1, output: expected_output, input: input)
   end
 end

--- a/test/cobol_to_elixir/data_division/group_items_test.exs
+++ b/test/cobol_to_elixir/data_division/group_items_test.exs
@@ -129,7 +129,7 @@ defmodule CobolToElixir.DataDivision.GroupItemsTest do
 
     expected_output = "Customer: 042MIKEB01021982SSE\n"
 
-    assert_output_equal(cobol, ElixirFromCobol.Test1, expected_output)
+    assert_output_equal(cobol, ElixirFromCobol.Test1, output: expected_output)
   end
 
   test "renders a move into a map child" do
@@ -158,6 +158,6 @@ defmodule CobolToElixir.DataDivision.GroupItemsTest do
 
     expected_output = "Customer: 042MIKEB01021982SSE\nCustomer: 042JOHND01021945SSE\n"
 
-    assert_output_equal(cobol, ElixirFromCobol.Test1, expected_output)
+    assert_output_equal(cobol, ElixirFromCobol.Test1, output: expected_output)
   end
 end

--- a/test/cobol_to_elixir/file_test.exs
+++ b/test/cobol_to_elixir/file_test.exs
@@ -1,0 +1,47 @@
+defmodule CobolToElixir.FileTest do
+  use CobolToElixirCase
+
+  test "file writing" do
+    cobol = """
+            >>SOURCE FORMAT FREE
+    IDENTIFICATION DIVISION.
+    PROGRAM-ID. foo123.
+    ENVIRONMENT DIVISION.
+    INPUT-OUTPUT SECTION.
+    FILE-CONTROL.
+      SELECT CustomerFile ASSIGN TO "Customer.dat"
+        ORGANIZATION IS LINE SEQUENTIAL
+        ACCESS IS SEQUENTIAL.
+    DATA DIVISION.
+    FILE SECTION.
+    FD CustomerFile.
+    01 CustomerData.
+      02 IDNum PIC 9(5).
+      02 CustName.
+        03 FirstName PIC X(15).
+        03 LastName PIC X(15).
+    WORKING-STORAGE SECTION.
+    01 WSCustomerData.
+      02 WSIDNum PIC 9(5).
+      02 WSCustName.
+        03 WSFirstName PIC X(15).
+        03 WSLastName PIC X(15).
+
+    PROCEDURE DIVISION.
+    OPEN OUTPUT CustomerFile.
+      MOVE 00001 TO IDNum.
+      MOVE 'Doug' TO FirstName.
+      MOVE "Thomas" TO LastName.
+      WRITE CustomerData
+      END-WRITE.
+    CLOSE CustomerFile.
+    STOP RUN.
+    """
+
+    validate_cobol_code(cobol)
+
+    assert %{output: "", files: %{"Customer.dat" => "00001Doug           Thomas\n"}} = execute_cobol_code!(cobol)
+
+    assert_output_equal(cobol, ElixirFromCobol.Foo123)
+  end
+end

--- a/test/cobol_to_elixir/procedure_division/paragraph_perform_test.exs
+++ b/test/cobol_to_elixir/procedure_division/paragraph_perform_test.exs
@@ -36,6 +36,6 @@ defmodule CobolToElixir.ProcedureDivision.ParagraphPerformTest do
     expected =
       "In Paragraph 1\nIn Paragraph 2\nIn Paragraph 3\nReturned to Paragraph 2\nReturned to Paragraph 1\nRepeat\n"
 
-    assert_output_equal(cobol, ElixirFromCobol.Proceduretest, expected)
+    assert_output_equal(cobol, ElixirFromCobol.Proceduretest, output: expected)
   end
 end

--- a/test/cobol_to_elixir/util_test.exs
+++ b/test/cobol_to_elixir/util_test.exs
@@ -16,7 +16,7 @@ defmodule CobolToElixir.UtilTest do
 
     validate_cobol_code(cobol)
 
-    assert CobolToElixir.Util.execute_cobol_code!(cobol) == "Hello World\n"
+    assert CobolToElixir.Util.execute_cobol_code!(cobol) == %{output: "Hello World\n", files: %{}}
   end
 
   test "execute_cobol_code!/2 raises on error" do

--- a/test/cobol_to_elixir_test.exs
+++ b/test/cobol_to_elixir_test.exs
@@ -58,14 +58,14 @@ defmodule CobolToElixirTest do
     input = [{1000, "John"}]
     expected_output = "Hello Mike \nHello John \nHello John "
     # First verify our cobol code runs and returns the right value
-    assert expected_output == execute_cobol_code!(cobol, input)
+    assert %{output: expected_output, files: %{}} == execute_cobol_code!(cobol, input)
     # Next run our converter to generate Elixir code
     assert {:ok, elixir_code} = CobolToElixir.convert(cobol, accept_via_message: true)
-    # Now run that Elixir code, and ensure the outtput matches our expected output
-    assert expected_output == execute_elixir_code(elixir_code, ElixirFromCobol.Test1, input)
+    # Now run that Elixir code, and ensure the output matches our expected output
+    assert %{output: expected_output, files: nil} == execute_elixir_code(elixir_code, ElixirFromCobol.Test1, input)
 
     # The below code is a one liner version of all of the above commands. Lets make sure that works too.
-    assert_output_equal(cobol, ElixirFromCobol.Test1, expected_output, input)
+    assert_output_equal(cobol, ElixirFromCobol.Test1, output: expected_output, input: input)
 
     # make sure validate_cobol_code raises on bad cobol
     assert_raise RuntimeError, ~r/^Error compiling cobol:/, fn -> validate_cobol_code("some bad code") end

--- a/test/support/cobol_to_elixir_case.ex
+++ b/test/support/cobol_to_elixir_case.ex
@@ -34,19 +34,19 @@ defmodule CobolToElixirCase do
   Input is a list of timeout/command values, e.g. [{1000, "John"}, {500, "Mike"}]
   would send "John" after 1 second, then "Mike" after another half a second.
 
-  Returns program output.
+  Returns map containing program output and any new files.
   """
   def execute_cobol_code!(cobol, input \\ []) do
-    CobolToElixir.Util.execute_cobol_code!(cobol, input)
+    Util.execute_cobol_code!(cobol, input)
   end
 
   @doc """
   Compiles and loads the given code into memory, runs the module, and unloads the module.
   Accepts list of input same as `execute_cobol_code!/2`.
 
-  Returns program output
+  Returns map containing program output and any new files.
   """
-  def execute_elixir_code(str, module, input) do
+  def execute_elixir_code(str, module, input, tmp_folder \\ nil) do
     log =
       capture_io(:stderr, fn ->
         Code.compile_string(str)
@@ -66,7 +66,13 @@ defmodule CobolToElixirCase do
     true = :code.delete(module)
     :code.purge(module)
 
-    io
+    files =
+      case tmp_folder do
+        nil -> nil
+        _ -> Util.get_new_files([], File.ls!(tmp_folder), tmp_folder)
+      end
+
+    %{output: io, files: files}
   end
 
   @doc """
@@ -77,15 +83,25 @@ defmodule CobolToElixirCase do
   3) Load and run the Elixir code, sending the specified inputs
   4) Assert that the output of both the cobol and Elixir programs matches the specififed output
   """
-  def assert_output_equal(cobol_text, module, output \\ "", input \\ []) do
-    cobol_output = execute_cobol_code!(cobol_text, input)
+  def assert_output_equal(cobol_text, module, opts \\ []) when is_list(opts) do
+    output = Keyword.get(opts, :output, "")
+    input = Keyword.get(opts, :input, [])
+    %{output: cobol_output, files: cobol_files} = execute_cobol_code!(cobol_text, input)
 
     if !is_nil(output) do
       ExUnit.Assertions.assert(cobol_output == output)
     end
 
-    {:ok, elixir_text} = CobolToElixir.convert(cobol_text, accept_via_message: true)
-    elixir_output = execute_elixir_code(elixir_text, module, input)
-    ExUnit.Assertions.assert(cobol_output == elixir_output)
+    tmp_folder = Util.generate_tmp_folder()
+    {:ok, elixir_text} = CobolToElixir.convert(cobol_text, accept_via_message: true, io_dir: tmp_folder)
+
+    try do
+      %{output: elixir_output, files: elixir_files} = execute_elixir_code(elixir_text, module, input, tmp_folder)
+
+      ExUnit.Assertions.assert(cobol_output == elixir_output)
+      ExUnit.Assertions.assert(cobol_files == elixir_files)
+    after
+      File.rm_rf!(tmp_folder)
+    end
   end
 end


### PR DESCRIPTION
Add initial support for `FILE SECTION`/`FD`/`OPEN OUTPUT`/`WRITE`.

Upgrade testing framework to return output files and compare in `assert_output_equal`.